### PR TITLE
Duplex-Safe Merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to `webklex/laravel-pdfmerger` will be documented in this fi
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## [UNRELEASED]
+## [Unreleased]
+
+### Added
+ - Added `duplexMerge` to support duplex-safe merging
+
+## [1.0.0] (2017-02-17)
 
 ### Added
 - new laravel-pdfmerger package
+
+
+[Unreleased]: https://github.com/Webklex/laravel-pdfmerger
+[1.0.0]: https://github.com/Webklex/laravel-pdfmerger/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ $oMerger->addPDF($file, [1, 3]); //Add page one and three only
 
 ```
 
+...merge files together but add blank pages to support duplex printing
+```php
+$oMerger->duplexMerge();
+```
+
 ...stream the merged content:
 
 ``` php

--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -188,6 +188,22 @@ class PDFMerger {
      * @throws \Exception if there are now PDFs to merge
      */
     public function merge($orientation = 'P') {
+        $this->doMerge($orientation, false);
+    }
+
+    /**
+     * Merges your provided PDFs and adds blank pages between documents as needed to allow duplex printing
+     * @param string $orientation
+     *
+     * @return void
+     *
+     * @throws \Exception if there are now PDFs to merge
+     */
+    public function duplexMerge($orientation = 'P') {
+        $this->doMerge($orientation, true);
+    }
+
+    protected function doMerge($orientation, $duplexSafe) {
 
         if ($this->aFiles->count() == 0) {
             throw new \Exception("No PDFs to merge.");
@@ -195,7 +211,7 @@ class PDFMerger {
 
         $oFPDI = $this->oFPDI;
 
-        $this->aFiles->each(function($file) use($oFPDI, $orientation){
+        $this->aFiles->each(function($file) use($oFPDI, $orientation, $duplexSafe){
             $file['orientation'] = is_null($file['orientation'])?$orientation:$file['orientation'];
             $count = $oFPDI->setSourceFile($file['name']);
             if ($file['pages'] == 'all') {
@@ -217,6 +233,10 @@ class PDFMerger {
                     $oFPDI->AddPage($file['orientation'], [$size['w'], $size['h']]);
                     $oFPDI->useTemplate($template);
                 }
+            }
+
+            if ($duplexSafe && $oFPDI->page % 2) {
+                $oFPDI->AddPage($file['orientation'], [$size['w'], $size['h']]);
             }
         });
     }


### PR DESCRIPTION
I have the following scenario:

I'm pre-generating invoices, each one can be a variable number of pages. I want to merge several invoices together so I can download and print them in one fell swoop. To save on paper, I want to print on both sides, but if I have two 1 page invoices that'll put two people's invoices on one piece of paper.

To address my sceanrio, I added `duplexMerge()` that will add a blank page after each PDF if it was an odd number of pages. To keep it DRY, I re-factored `merge` to a protected function named `doMerge` and then call that from `merge` and `duplexMerge` - didn't want to have to change the public API. If you'd prefer a different approach, let me know and I can refactor.

Thanks for this package!