### PR TITLE
Update namespace of FPDI

### DIFF
--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -12,7 +12,7 @@
 
 namespace Webklex\PDFMerger;
 
-use fpdi\FPDI;
+use FPDI;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 


### PR DESCRIPTION
When I tested #4 - I still had `itbz/fpdi` stuck in my `composer.lock` file and it didn't get removed, so all my testing was still using that package...

Anyway, looks like `setasign/fpdi` 1.6.2 namespaces `FPDI` differently than the `itbz` package, making that change here.

Sorry!