### PR TITLE
Dont force portrait orientation during merge if not specified

### DIFF
--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -228,7 +228,7 @@ class PDFMerger {
                 for ($i = 1; $i <= $count; $i++) {
                     $template   = $oFPDI->importPage($i);
                     $size       = $oFPDI->getTemplateSize($template);
-                    $autoOrientation = $file['orientation'] ?? $size['orientation'];
+                    $autoOrientation = isset($file['orientation']) ? $file['orientation'] : $size['orientation'];
 
                     $oFPDI->AddPage($autoOrientation, [$size['width'], $size['height']]);
                     $oFPDI->useTemplate($template);
@@ -239,7 +239,7 @@ class PDFMerger {
                         throw new \Exception("Could not load page '$page' in PDF '" . $file['name'] . "'. Check that the page exists.");
                     }
                     $size = $oFPDI->getTemplateSize($template);
-                    $autoOrientation = $file['orientation'] ?? $size['orientation'];
+                    $autoOrientation = isset($file['orientation']) ? $file['orientation'] : $size['orientation'];
 
                     $oFPDI->AddPage($autoOrientation, [$size['width'], $size['height']]);
                     $oFPDI->useTemplate($template);

--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -195,7 +195,7 @@ class PDFMerger {
      *
      * @throws \Exception if there are now PDFs to merge
      */
-    public function merge($orientation = 'P') {
+    public function merge($orientation = null) {
         $this->doMerge($orientation, false);
     }
 
@@ -228,18 +228,20 @@ class PDFMerger {
                 for ($i = 1; $i <= $count; $i++) {
                     $template   = $oFPDI->importPage($i);
                     $size       = $oFPDI->getTemplateSize($template);
+                    $autoOrientation = $file['orientation'] ?? $size['orientation'];
 
-                    $oFPDI->AddPage($file['orientation'], [$size['width'], $size['height']]);
+                    $oFPDI->AddPage($autoOrientation, [$size['width'], $size['height']]);
                     $oFPDI->useTemplate($template);
                 }
             } else {
                 foreach ($file['pages'] as $page) {
                     if (!$template = $oFPDI->importPage($page)) {
-                        throw new \Exception("Could not load page '$page' in PDF '".$file['name']."'. Check that the page exists.");
+                        throw new \Exception("Could not load page '$page' in PDF '" . $file['name'] . "'. Check that the page exists.");
                     }
                     $size = $oFPDI->getTemplateSize($template);
+                    $autoOrientation = $file['orientation'] ?? $size['orientation'];
 
-                    $oFPDI->AddPage($file['orientation'], [$size['width'], $size['height']]);
+                    $oFPDI->AddPage($autoOrientation, [$size['width'], $size['height']]);
                     $oFPDI->useTemplate($template);
                 }
             }


### PR DESCRIPTION
#28 

By default, the orientation of the file can either come from the file itself, or passed in as a parameter during merge. The default argument for the orientation parametrer is 'P', thus implictly merging all PDF files in portrait mode. 

This fix sets the default parameter to null, and the orientation will be calculated automatically if both file orientation and the orientation parameter are not specified.

