### PR TITLE
fixes no response being send on download

### DIFF
--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -106,11 +106,12 @@ class PDFMerger {
      */
     public function download(){
         $output = $this->output();
-        return new Response($output, 200, [
+        $response = new Response($output, 200, [
             'Content-Type' => 'application/pdf',
             'Content-Disposition' =>  'attachment; filename="' . $this->fileName . '"',
             'Content-Length' => strlen($output),
         ]);
+        return $response->send();
     }
 
     /**


### PR DESCRIPTION
After updating to version 1.3.1, no file download response was triggered when calling the download function, which may result in empty pdf files #31. 

This is due to the new use of the "Illuminate\Http\Response" class inside of the `download` method.

```
        $output = $this->output();
        return new Response($output, 200, [
            'Content-Type' => 'application/pdf',
            'Content-Disposition' =>  'attachment; filename="' . $this->fileName . '"',
            'Content-Length' => strlen($output),
        ]);
```

The reason for the problem is that the response is generated and returned but not sent. To do this, we have to call the `send` method of the response class.

```
        $output = $this->output();
        $response = new Response($output, 200, [
            'Content-Type' => 'application/pdf',
            'Content-Disposition' =>  'attachment; filename="' . $this->fileName . '"',
            'Content-Length' => strlen($output),
        ]);
        return $response->send();
```

This solves the problem!
(tested on laravel 9)