### PR TITLE
Fixed duplexMerge page issue

### DIFF
--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -246,7 +246,7 @@ class PDFMerger {
                 }
             }
 
-            if ($duplexSafe && $oFPDI->page % 2) {
+            if ($duplexSafe && $oFPDI->PageNo() % 2) {
                 $oFPDI->AddPage($file['orientation'], [$size['width'], $size['height']]);
             }
         });


### PR DESCRIPTION
issue #24 

Error: Cannot access protected property setasign\Fpdi\Fpdi::$page
         `if ($duplexSafe && $oFPDI->page % 2)`
         
Fix: changing line 249 in PDFMerger
`if ($duplexSafe && $oFPDI->PageNo() % 2)`