### PR TITLE
Add Functionality to Add PDFs from Amazon S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ $oMerger->addString(file_get_contents('/path/to/project/vendors/webklex/laravel-
 
 ```
 
+...add files from s3:
+
+``` php
+$oMerger->addPDFFromS3('/path/examples/pdf_two.pdf'), [1]);
+
+```
+
 ...select the pages you want to merge:
 
 ``` php

--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -12,12 +12,14 @@
 
 namespace Webklex\PDFMerger;
 
+use Illuminate\Support\Carbon;
 use setasign\Fpdi\Fpdi as FPDI;
 use setasign\Fpdi\PdfParser\StreamReader;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
 
 class PDFMerger {
 
@@ -157,6 +159,38 @@ class PDFMerger {
         $this->tmpFiles->push($filePath);
 
         return $this->addPDF($filePath, $pages, $orientation);
+    }
+
+    /**
+     * Add a PDF from S3
+     *
+     * @param string $filePath
+     * @param string $pages
+     * @param string|null $orientation
+     * @param int $tempURLMinutes
+     *
+     * @return self
+     *
+     * @throws \Exception if the given pages aren't correct or the file cannot be located
+     */
+    public function addPDFFromS3($filePath, $pages = 'all', $orientation = null, $tempURLMinutes = 5) {
+        if (Storage::disk('s3')->exists($filePath)) {
+            if (!is_array($pages) && strtolower($pages) != 'all') {
+                throw new \Exception("Invalid format for pages: '$pages'");
+            }
+
+            $temporaryUrl = Storage::disk('s3')->temporaryUrl($filePath, Carbon::now()->addMinutes($tempURLMinutes));
+
+            $this->aFiles->push([
+                'name'  => $temporaryUrl,
+                'pages' => $pages,
+                'orientation' => $orientation
+            ]);
+        } else {
+            throw new \Exception("Could not locate PDF on '$filePath'");
+        }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Currently, the only way to add PDFs is through the function `addPDF()` that can only be linked to pdfs that already exist on the local, and integration or inclusion to the plugin to pull pdfs from Amazon S3 buckets before including them would be very useful to users. This addition would provide more flexibility and better user experience, helping users merge from pdfs in the cloud without necessarily downloading them locally.
For us to achieve this, we propose to add another function `addPDFFromS3()` to the plugin that will factor the file’s path on S3, and all the other parameters familiar with the existing `addPDF()` function.