### PR TITLE
Added support for importing link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=5.5.9",
         "illuminate/support": ">=5.0",
         "setasign/fpdf": "1.8.*",
-        "setasign/fpdi": "^2.0"
+        "setasign/fpdi": "^2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
Since FPDI 2.4.0 it's supported to import external links but it has to be activated by a parameter. This PR sets this parameter to true by default as I don't see any reason to not import the links - alternatively I can also make this configurable per pdf (if you wish).

Additionally I added support for the new parserParams - at the end this is currently only be used by the FPDI PDF-Parser to handle encrypted pdfs. More about this can be found [here](https://manuals.setasign.com/fpdi-pdf-parser-manual/v2/protected-pdf-documents/).