### PR TITLE
Update PDFMerger.php

### DIFF
--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -144,7 +144,7 @@ class PDFMerger {
     }
 
     /**
-     * Set the final filename
+     * Add a string for inclusion in the merge
      * @param string $string
      * @param mixed $pages
      * @param mixed $orientation

--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -136,7 +136,7 @@ class PDFMerger {
      * Set the final filename
      * @param string $fileName
      *
-     * @return string
+     * @return self
      */
     public function setFileName($fileName){
         $this->fileName = $fileName;
@@ -149,7 +149,7 @@ class PDFMerger {
      * @param mixed $pages
      * @param mixed $orientation
      *
-     * @return string
+     * @return self
      */
     public function addString($string, $pages = 'all', $orientation = null){
 
@@ -221,7 +221,7 @@ class PDFMerger {
         $oFPDI = $this->oFPDI;
 
         $this->aFiles->each(function($file) use($oFPDI, $orientation, $duplexSafe){
-            $file['orientation'] = is_null($file['orientation'])?$orientation:$file['orientation'];
+            $file['orientation'] = $file['orientation'] ?? $orientation;
             $count = $oFPDI->setSourceFile(StreamReader::createByString(file_get_contents($file['name'])));
 
             if ($file['pages'] == 'all') {
@@ -229,7 +229,7 @@ class PDFMerger {
                 for ($i = 1; $i <= $count; $i++) {
                     $template   = $oFPDI->importPage($i);
                     $size       = $oFPDI->getTemplateSize($template);
-                    $autoOrientation = isset($file['orientation']) ? $file['orientation'] : $size['orientation'];
+                    $autoOrientation = $file['orientation'] ?? $size['orientation'];
 
                     $oFPDI->AddPage($autoOrientation, [$size['width'], $size['height']]);
                     $oFPDI->useTemplate($template);
@@ -240,7 +240,7 @@ class PDFMerger {
                         throw new \Exception("Could not load page '$page' in PDF '" . $file['name'] . "'. Check that the page exists.");
                     }
                     $size = $oFPDI->getTemplateSize($template);
-                    $autoOrientation = isset($file['orientation']) ? $file['orientation'] : $size['orientation'];
+                    $autoOrientation = $file['orientation'] ?? $size['orientation'];
 
                     $oFPDI->AddPage($autoOrientation, [$size['width'], $size['height']]);
                     $oFPDI->useTemplate($template);


### PR DESCRIPTION
This pull request includes (**TLDR;**):
- fixed return type in docstring
- code simplification using php shorthand

Return type modifications for method chaining:

* [`src/PDFMerger/PDFMerger.php`](diffhunk://#diff-bd5d2df9b1c52b03817feaec79c04e3138ba75a5f8ec7e9516d5e990ce97a1a8L139-R139): Changed the return type of the `setFileName` method from `string` to `self` to allow method chaining.
* [`src/PDFMerger/PDFMerger.php`](diffhunk://#diff-bd5d2df9b1c52b03817feaec79c04e3138ba75a5f8ec7e9516d5e990ce97a1a8L152-R152): Changed the return type of the `addString` method from `string` to `self` to allow method chaining.

Code simplification using null coalescing operator:

* [`src/PDFMerger/PDFMerger.php`](diffhunk://#diff-bd5d2df9b1c52b03817feaec79c04e3138ba75a5f8ec7e9516d5e990ce97a1a8L224-R232): Replaced `isset` checks with the null coalescing operator (`??`) in the `doMerge` method to simplify the code. [[1]](diffhunk://#diff-bd5d2df9b1c52b03817feaec79c04e3138ba75a5f8ec7e9516d5e990ce97a1a8L224-R232) [[2]](diffhunk://#diff-bd5d2df9b1c52b03817feaec79c04e3138ba75a5f8ec7e9516d5e990ce97a1a8L243-R243)